### PR TITLE
Fix print script path and newline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/scripts/python/print_folder_mac.py
+++ b/scripts/python/print_folder_mac.py
@@ -2,7 +2,8 @@ import os
 import subprocess
 import time
 
-FOLDER_PATH = "/Users/haitham/Downloads/MyPrintFiles"  # Update to your actual folder
+# Automatically use the directory where this script resides
+FOLDER_PATH = os.path.dirname(os.path.abspath(__file__))
 
 def print_file(filepath):
     ext = os.path.splitext(filepath)[1].lower()


### PR DESCRIPTION
## Summary
- use the script's folder as the default path in `print_folder_mac.py`
- add newline at end of file
- create `.gitignore` for caches and bytecode

## Testing
- `python3 -m py_compile scripts/python/print_folder_mac.py`
- `python3 scripts/python/print_folder_mac.py`

------
https://chatgpt.com/codex/tasks/task_e_684466774b508331ae61e280fd9c931b